### PR TITLE
[sd-extension] Add AWS MSK service discovery plugin

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -103,7 +103,7 @@ BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 DOCKERFILE_PATH         ?= ./Dockerfile
 DOCKERBUILD_CONTEXT     ?= ./
-DOCKER_REPO             ?= prom
+DOCKER_REPO             ?= zywillc
 
 DOCKER_ARCHS            ?= amd64
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -539,11 +539,11 @@ var expectedConf = &Config{
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&aws.MSKSDConfig{
-					Region:          "us-east-1",
-					AccessKey:       "access",
-					SecretKey:       "mysecret",
-					Profile:         "profile",
-					RefreshInterval: model.Duration(60 * time.Second),
+					Region:            "us-east-1",
+					AccessKey:         "access",
+					SecretKey:         "mysecret",
+					Profile:           "profile",
+					RefreshInterval:   model.Duration(60 * time.Second),
 					ClusterNameFilter: "msk_demo",
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -527,6 +527,28 @@ var expectedConf = &Config{
 			},
 		},
 		{
+			JobName: "service-msk",
+
+			HonorTimestamps: true,
+			ScrapeInterval:  model.Duration(15 * time.Second),
+			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&aws.MSKSDConfig{
+					Region:          "us-east-1",
+					AccessKey:       "access",
+					SecretKey:       "mysecret",
+					Profile:         "profile",
+					RefreshInterval: model.Duration(60 * time.Second),
+					ClusterNameFilter: "msk_demo",
+				},
+			},
+		},
+		{
 			JobName: "service-lightsail",
 
 			HonorTimestamps: true,

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -226,6 +226,14 @@ scrape_configs:
               - web
               - db
 
+  - job_name: service-msk
+    msk_sd_configs:
+      - region: us-east-1
+        access_key: access
+        secret_key: mysecret
+        profile: profile
+        cluster_name_filter: msk_demo
+
   - job_name: service-lightsail
     lightsail_sd_configs:
       - region: us-east-1

--- a/config/testdata/roundtrip.good.yml
+++ b/config/testdata/roundtrip.good.yml
@@ -84,6 +84,13 @@ scrape_configs:
               - web
               - db
 
+    msk_sd_configs:
+      - region: us-east-1
+        access_key: access
+        secret_key: <secret>
+        profile: profile
+        cluster_name_filter: msk_demo
+
     file_sd_configs:
       - files:
           - single/file.yml

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -37,12 +37,12 @@ import (
 )
 
 const (
-	mskLabel                  = model.MetaLabelPrefix + "msk_"
-	mskLabelClusterName		  = mskLabel + "cluster_name"
-	mskLabelTag               = mskLabel + "tag_"
-	mskLabelKafkaVersion	  = mskLabel + "kafka_version"
-	mskLabelClusterSize       = mskLabel + "cluster_size"
-	mskLabelSeparator         = ","
+	mskLabel             = model.MetaLabelPrefix + "msk_"
+	mskLabelClusterName  = mskLabel + "cluster_name"
+	mskLabelTag          = mskLabel + "tag_"
+	mskLabelKafkaVersion = mskLabel + "kafka_version"
+	mskLabelClusterSize  = mskLabel + "cluster_size"
+	mskLabelSeparator    = ","
 )
 
 // DefaultMSKSDConfig is the default MSK SD configuration.
@@ -56,13 +56,13 @@ func init() {
 
 // MSKSDConfig is the configuration for MSK based service discovery.
 type MSKSDConfig struct {
-	Region          	string         `yaml:"region"`
-	AccessKey       	string         `yaml:"access_key,omitempty"`
-	SecretKey       	config.Secret  `yaml:"secret_key,omitempty"`
-	Profile         	string         `yaml:"profile,omitempty"`
-	RoleARN         	string         `yaml:"role_arn,omitempty"`
-	RefreshInterval 	model.Duration `yaml:"refresh_interval,omitempty"`
-	ClusterNameFilter	string 		   `yaml:"cluster_name_filter,omitempty"`
+	Region            string         `yaml:"region"`
+	AccessKey         string         `yaml:"access_key,omitempty"`
+	SecretKey         config.Secret  `yaml:"secret_key,omitempty"`
+	Profile           string         `yaml:"profile,omitempty"`
+	RoleARN           string         `yaml:"role_arn,omitempty"`
+	RefreshInterval   model.Duration `yaml:"refresh_interval,omitempty"`
+	ClusterNameFilter string         `yaml:"cluster_name_filter,omitempty"`
 }
 
 // Name returns the name of the MSK Config.
@@ -93,7 +93,7 @@ type MSKDiscovery struct {
 	*refresh.Discovery
 	logger log.Logger
 	cfg    *MSKSDConfig
-	kafka    *kafka.Kafka
+	kafka  *kafka.Kafka
 }
 
 // NewMSKDiscovery returns a new MSKDiscovery which periodically refreshes its targets.
@@ -145,7 +145,6 @@ func (d *MSKDiscovery) mskClient(ctx context.Context) (*kafka.Kafka, error) {
 	return d.kafka, nil
 }
 
-
 func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	mskClient, err := d.mskClient(ctx)
 	if err != nil {
@@ -180,7 +179,7 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	}
 
 	exporterPorts := map[string]int{
-		"jmx": 	11001,
+		"jmx":  11001,
 		"node": 11002,
 	}
 
@@ -209,8 +208,8 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 			cluster, err := mskClient.DescribeCluster(descClusterInput)
 
-			for _, brokerUrl := range strings.Split(*brokers.BootstrapBrokerString, ",") {
-				host, _, _ := net.SplitHostPort(brokerUrl)
+			for _, brokerURL := range strings.Split(*brokers.BootstrapBrokerString, mskLabelSeparator) {
+				host, _, _ := net.SplitHostPort(brokerURL)
 				addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 				target := model.LabelSet{
 					model.AddressLabel: model.LabelValue(addr),

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -1,0 +1,237 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	mskLabel                  = model.MetaLabelPrefix + "msk_"
+	mskLabelClusterName		  = mskLabel + "cluster_name"
+	mskLabelTag               = mskLabel + "tag_"
+	mskLabelKafkaVersion	  = mskLabel + "kafka_version"
+	mskLabelClusterSize       = mskLabel + "cluster_size"
+	mskLabelSeparator         = ","
+)
+
+// DefaultMSKSDConfig is the default MSK SD configuration.
+var DefaultMSKSDConfig = MSKSDConfig{
+	RefreshInterval: model.Duration(60 * time.Second),
+}
+
+func init() {
+	discovery.RegisterConfig(&MSKSDConfig{})
+}
+
+// MSKSDConfig is the configuration for MSK based service discovery.
+type MSKSDConfig struct {
+	Region          	string         `yaml:"region"`
+	AccessKey       	string         `yaml:"access_key,omitempty"`
+	SecretKey       	config.Secret  `yaml:"secret_key,omitempty"`
+	Profile         	string         `yaml:"profile,omitempty"`
+	RoleARN         	string         `yaml:"role_arn,omitempty"`
+	RefreshInterval 	model.Duration `yaml:"refresh_interval,omitempty"`
+	ClusterNameFilter	string 		   `yaml:"cluster_name_filter,omitempty"`
+}
+
+// Name returns the name of the MSK Config.
+func (*MSKSDConfig) Name() string { return "msk" }
+
+// NewDiscoverer returns a Discoverer for the MSK Config.
+func (c *MSKSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewMSKDiscovery(c, opts.Logger), nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for the MSK Config.
+func (c *MSKSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultMSKSDConfig
+	type plain MSKSDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+	if c.Region == "" {
+		c.Region = "us-east-1"
+	}
+	return nil
+}
+
+// MSKDiscovery periodically performs MSK-SD requests. It implements
+// the Discoverer interface.
+type MSKDiscovery struct {
+	*refresh.Discovery
+	logger log.Logger
+	cfg    *MSKSDConfig
+	kafka    *kafka.Kafka
+}
+
+// NewMSKDiscovery returns a new MSKDiscovery which periodically refreshes its targets.
+func NewMSKDiscovery(conf *MSKSDConfig, logger log.Logger) *MSKDiscovery {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	d := &MSKDiscovery{
+		logger: logger,
+		cfg:    conf,
+	}
+	d.Discovery = refresh.NewDiscovery(
+		logger,
+		"MSK",
+		time.Duration(d.cfg.RefreshInterval),
+		d.refresh,
+	)
+	return d
+}
+
+func (d *MSKDiscovery) mskClient(ctx context.Context) (*kafka.Kafka, error) {
+	if d.kafka != nil {
+		return d.kafka, nil
+	}
+
+	creds := credentials.NewStaticCredentials(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
+	if d.cfg.AccessKey == "" && d.cfg.SecretKey == "" {
+		creds = nil
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Region:      &d.cfg.Region,
+			Credentials: creds,
+		},
+		Profile: d.cfg.Profile,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create aws session")
+	}
+
+	if d.cfg.RoleARN != "" {
+		creds := stscreds.NewCredentials(sess, d.cfg.RoleARN)
+		d.kafka = kafka.New(sess, &aws.Config{Credentials: creds})
+	} else {
+		d.kafka = kafka.New(sess)
+	}
+
+	return d.kafka, nil
+}
+
+
+func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	mskClient, err := d.mskClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var clustersArn []*string
+	input := &kafka.ListClustersInput{}
+	if d.cfg.ClusterNameFilter != "" {
+		input.SetClusterNameFilter(d.cfg.ClusterNameFilter)
+	}
+
+	for {
+		result, err := mskClient.ListClusters(input)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			break
+		}
+
+		var clustersArnPaged []*string
+		for _, c := range result.ClusterInfoList {
+			clustersArnPaged = append(clustersArnPaged, c.ClusterArn)
+		}
+		clustersArn = append(clustersArn, clustersArnPaged...)
+		input.NextToken = result.NextToken
+
+		if result.NextToken == nil {
+			break
+		}
+	}
+
+	exporterPorts := map[string]int{
+		"jmx": 	11001,
+		"node": 11002,
+	}
+
+	var tgs []*targetgroup.Group
+
+	for exporter, port := range exporterPorts {
+		tg := &targetgroup.Group{
+			Source: d.cfg.Region,
+			Labels: model.LabelSet{
+				"exporter": model.LabelValue(exporter),
+			},
+		}
+
+		for _, clusterArn := range clustersArn {
+			getBrokersInput := &kafka.GetBootstrapBrokersInput{
+				ClusterArn: clusterArn,
+			}
+			brokers, err := mskClient.GetBootstrapBrokers(getBrokersInput)
+			if err != nil {
+				continue
+			}
+
+			descClusterInput := &kafka.DescribeClusterInput{
+				ClusterArn: clusterArn,
+			}
+
+			cluster, err := mskClient.DescribeCluster(descClusterInput)
+
+			for _, brokerUrl := range strings.Split(*brokers.BootstrapBrokerString, ",") {
+				host, _, _ := net.SplitHostPort(brokerUrl)
+				addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+				target := model.LabelSet{
+					model.AddressLabel: model.LabelValue(addr),
+				}
+				if err == nil {
+					target[mskLabelClusterName] = model.LabelValue(*cluster.ClusterInfo.ClusterName)
+					for k, v := range cluster.ClusterInfo.Tags {
+						if k == "" || v == nil {
+							continue
+						}
+						name := strutil.SanitizeLabelName(k)
+						target[mskLabelTag+model.LabelName(name)] = model.LabelValue(*v)
+					}
+					target[mskLabelKafkaVersion] = model.LabelValue(*cluster.ClusterInfo.CurrentVersion)
+					target[mskLabelClusterSize] = model.LabelValue(fmt.Sprint(*cluster.ClusterInfo.NumberOfBrokerNodes))
+				}
+				tg.Targets = append(tg.Targets, target)
+			}
+		}
+		tgs = append(tgs, tg)
+	}
+
+	return tgs, nil
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1008,6 +1008,41 @@ way to filter targets based on arbitrary labels. For users with thousands of
 instances it can be more efficient to use the EC2 API directly which has
 support for filtering instances.
 
+### `<msk_sd_config>`
+
+MSK SD configurations allow retrieving scrape targets from AWS MSK
+instances. The broker `jmx` and `node` exporter url were used.
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_msk_cluster_name`: the MSK cluster name
+* `__meta_msk_cluster_size`: the size of MSK cluster
+* `__meta_msk_kafka_version`: the current version of Kafka the MSK cluster is running
+* `__meta_msk_tag_<tagkey>`: each tag value of the cluster
+
+See below for the configuration options for EC2 discovery:
+
+```yaml
+# The AWS region. If blank, the region from the instance metadata is used.
+[ region: <string> ]
+
+# The AWS API keys. If blank, the environment variables `AWS_ACCESS_KEY_ID`
+# and `AWS_SECRET_ACCESS_KEY` are used.
+[ access_key: <string> ]
+[ secret_key: <secret> ]
+# Named AWS profile used to connect to the API.
+[ profile: <string> ]
+
+# AWS Role ARN, an alternative to using AWS API keys.
+[ role_arn: <string> ]
+
+# Refresh interval to re-read the instance list.
+[ refresh_interval: <duration> | default = 60s ]
+
+# Filter the desired clusters by name
+[ cluster_name_filter: <string>]
+```
+
 ### `<openstack_sd_config>`
 
 OpenStack SD configurations allow retrieving scrape targets from OpenStack Nova
@@ -2562,6 +2597,10 @@ dns_sd_configs:
 # List of EC2 service discovery configurations.
 ec2_sd_configs:
   [ - <ec2_sd_config> ... ]
+
+# List of MSK service discovery configurations.
+msk_sd_configs:
+  [ - <msk_sd_config> ... ]
 
 # List of Eureka service discovery configurations.
 eureka_sd_configs:


### PR DESCRIPTION
### `<msk_sd_config>`

MSK SD configurations allow retrieving scrape targets from AWS MSK
instances. The broker `jmx` and `node` exporter url were used.

The following meta labels are available on targets during [relabeling](#relabel_config):

* `__meta_msk_cluster_name`: the MSK cluster name
* `__meta_msk_cluster_size`: the size of MSK cluster
* `__meta_msk_kafka_version`: the current version of Kafka the MSK cluster is running
* `__meta_msk_tag_<tagkey>`: each tag value of the cluster

See below for the configuration options for EC2 discovery:

```yaml
# The AWS region. If blank, the region from the instance metadata is used.
[ region: <string> ]
# The AWS API keys. If blank, the environment variables `AWS_ACCESS_KEY_ID`
# and `AWS_SECRET_ACCESS_KEY` are used.
[ access_key: <string> ]
[ secret_key: <secret> ]
# Named AWS profile used to connect to the API.
[ profile: <string> ]
# AWS Role ARN, an alternative to using AWS API keys.
[ role_arn: <string> ]
# Refresh interval to re-read the instance list.
[ refresh_interval: <duration> | default = 60s ]
# Filter the desired clusters by name
[ cluster_name_filter: <string>]
```